### PR TITLE
RSDK-9541: create pictures directories if directories don't exist

### DIFF
--- a/src/tracker/face_id/identifier.py
+++ b/src/tracker/face_id/identifier.py
@@ -114,7 +114,14 @@ class FaceIdentifier:
         path_to_known_faces = self.cfg.path_to_known_faces.value
         if path_to_known_faces is None:
             return
+        if not os.path.exists(path_to_known_faces):
+            LOGGER.warning(
+                "Directory for known faces '%s' did not exist and was created.",
+                path_to_known_faces,
+            )
+            os.makedirs(path_to_known_faces)
         all_entries = os.listdir(path_to_known_faces)
+
         directories = [
             entry
             for entry in all_entries

--- a/src/tracker/tracker.py
+++ b/src/tracker/tracker.py
@@ -534,6 +534,13 @@ class Tracker:
 
         if not self.path_to_known_persons:
             return
+        if not os.path.exists(self.path_to_known_persons):
+            LOGGER.warning(
+                "Directory for known persons '%s' did not exist and was created.",
+                self.path_to_known_persons,
+            )
+            os.makedirs(self.path_to_known_persons)
+
         all_entries = os.listdir(self.path_to_known_persons)
         directories = [
             entry


### PR DESCRIPTION
Sometimes the log warning is not logged but the file is created.
Manual test was to config a non-existing directory.
Check if the directory is created
use `recompute_embeddings()` do cmd 
get a label