### PR TITLE
refactor duplicated code in osnet.py

### DIFF
--- a/src/tracker/encoder/os_net/osnet.py
+++ b/src/tracker/encoder/os_net/osnet.py
@@ -224,7 +224,7 @@ class ChannelGate(nn.Module):
 class OSBlock(nn.Module):
     """Omni-scale feature learning block."""
 
-    def __init__(self, in_channels, out_channels, reduction=4, T=4, **kwargs):
+    def __init__(self, in_channels, out_channels, reduction=4, T=4):
         super(OSBlock, self).__init__()
         assert T >= 1
         assert out_channels >= reduction and out_channels % reduction == 0
@@ -257,7 +257,7 @@ class OSBlock(nn.Module):
 class OSBlockINin(nn.Module):
     """Omni-scale feature learning block with instance normalization."""
 
-    def __init__(self, in_channels, out_channels, reduction=4, T=4, **kwargs):
+    def __init__(self, in_channels, out_channels, reduction=4, T=4):
         super(OSBlockINin, self).__init__()
         assert T >= 1
         assert out_channels >= reduction and out_channels % reduction == 0

--- a/src/tracker/encoder/os_net/osnet.py
+++ b/src/tracker/encoder/os_net/osnet.py
@@ -483,77 +483,28 @@ def init_pretrained_weights(model, key=""):
 ##########
 # Instantiation
 ##########
-def osnet_ain_x1_0(num_classes=1000, pretrained=True, loss="softmax", **kwargs):
-    model = OSNet(
-        num_classes,
-        blocks=[
-            [OSBlockINin, OSBlockINin],
-            [OSBlock, OSBlockINin],
-            [OSBlockINin, OSBlock],
-        ],
-        layers=[2, 2, 2],
-        channels=[64, 256, 384, 512],
-        loss=loss,
-        conv1_IN=True,
-        **kwargs,
-    )
-    if pretrained:
-        init_pretrained_weights(model, key="osnet_ain_x1_0")
-    return model
+def create_osnet_ain(channels, name):
+    def osnet_ain(num_classes=1000, pretrained=True, loss="softmax", **kwargs):
+        model = OSNet(
+            num_classes,
+            blocks=[
+                [OSBlockINin, OSBlockINin],
+                [OSBlock, OSBlockINin],
+                [OSBlockINin, OSBlock],
+            ],
+            layers=[2, 2, 2],
+            channels=channels,
+            loss=loss,
+            conv1_IN=True,
+            **kwargs,
+        )
+        if pretrained:
+            init_pretrained_weights(model, key=name)
+        return model
+    return osnet_ain
 
 
-def osnet_ain_x0_75(num_classes=1000, pretrained=True, loss="softmax", **kwargs):
-    model = OSNet(
-        num_classes,
-        blocks=[
-            [OSBlockINin, OSBlockINin],
-            [OSBlock, OSBlockINin],
-            [OSBlockINin, OSBlock],
-        ],
-        layers=[2, 2, 2],
-        channels=[48, 192, 288, 384],
-        loss=loss,
-        conv1_IN=True,
-        **kwargs,
-    )
-    if pretrained:
-        init_pretrained_weights(model, key="osnet_ain_x0_75")
-    return model
-
-
-def osnet_ain_x0_5(num_classes=1000, pretrained=True, loss="softmax", **kwargs):
-    model = OSNet(
-        num_classes,
-        blocks=[
-            [OSBlockINin, OSBlockINin],
-            [OSBlock, OSBlockINin],
-            [OSBlockINin, OSBlock],
-        ],
-        layers=[2, 2, 2],
-        channels=[32, 128, 192, 256],
-        loss=loss,
-        conv1_IN=True,
-        **kwargs,
-    )
-    if pretrained:
-        init_pretrained_weights(model, key="osnet_ain_x0_5")
-    return model
-
-
-def osnet_ain_x0_25(num_classes=1000, pretrained=True, loss="softmax", **kwargs):
-    model = OSNet(
-        num_classes,
-        blocks=[
-            [OSBlockINin, OSBlockINin],
-            [OSBlock, OSBlockINin],
-            [OSBlockINin, OSBlock],
-        ],
-        layers=[2, 2, 2],
-        channels=[16, 64, 96, 128],
-        loss=loss,
-        conv1_IN=True,
-        **kwargs,
-    )
-    if pretrained:
-        init_pretrained_weights(model, key="osnet_ain_x0_25")
-    return model
+osnet_ain_x1_0  = create_osnet_ain([64, 256, 384, 512], "osnet_ain_x1_0")
+osnet_ain_x0_75 = create_osnet_ain([48, 192, 288, 384], "osnet_ain_x0_75")
+osnet_ain_x0_5  = create_osnet_ain([32, 128, 192, 256], "osnet_ain_x0_5")
+osnet_ain_x0_25 = create_osnet_ain([16,  64,  96, 128], "osnet_ain_x0_25")

--- a/src/tracker/encoder/os_net/osnet.py
+++ b/src/tracker/encoder/os_net/osnet.py
@@ -222,7 +222,7 @@ class ChannelGate(nn.Module):
 
 
 class OSBlock(nn.Module):
-    """Omni-scale feature learning block."""
+    """Omni-scale feature learning block with optional instance normalization."""
 
     def __init__(self, in_channels, out_channels, reduction=4, T=4,
                  normalize_instance=False):

--- a/src/tracker/encoder/os_net/osnet.py
+++ b/src/tracker/encoder/os_net/osnet.py
@@ -225,7 +225,7 @@ class OSBlock(nn.Module):
     """Omni-scale feature learning block with optional instance normalization."""
 
     def __init__(self, in_channels, out_channels, reduction=4, T=4,
-                 normalize_instance=False):
+                 normalize_instance=False, **kwargs):
         super(OSBlock, self).__init__()
         assert T >= 1
         assert out_channels >= reduction and out_channels % reduction == 0
@@ -263,9 +263,9 @@ class OSBlock(nn.Module):
 class OSBlockINin(OSBlock):
     """Omni-scale feature learning block with instance normalization."""
 
-    def __init__(self, in_channels, out_channels, reduction=4, T=4):
-        super(OSBlockINin, self).__init__(
-            in_channels, out_channels, reduction, T, normalize_instance=True)
+    def __init__(self, in_channels, out_channels, reduction=4, T=4, **kwargs):
+        super(OSBlockINin, self).__init__(in_channels, out_channels, reduction,
+                                          T, normalize_instance=True, **kwargs)
 
 
 ##########


### PR DESCRIPTION
No changes to behavior are intended! I haven't actually tried any of this out; I'm unsure how to run it myself. Even worse than that, I don't know what any of this code does. So, if I've added a bug, I might not even notice. :grimacing: 

`OSBlock` and `OSBlockINin` were almost identical. So, I added a boolean to distinguish them, and merged the rest of their implementations together.

Similarly, `osnet_ain_x1_0`, `osnet_ain_x0_75`, `osnet_ain_x0_5`, and `osnet_ain_x0_25` were identical except for one list and one string. So, I made a function-builder that takes a list and a string and returns one of these functions.

By removing duplicated code, a) if there are any bugs we only need to fix them once instead of multiple times, b) if we need to add new features in the future, we only need to add them once instead of in multiple places, and c) someone new to the codebase (me!) doesn't need to read/learn as much code because it's now clear which parts are the same.

If the PR is too big on its own, my hope is that reading commit-by-commit might be simple, too.