### PR TITLE
Start cleaning up type annotations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pytest-asyncio
 pylint
 mypy==1.15.0
 mypy-extensions==1.0.0
+types-tabulate==0.9.0.20241207
 
 ## for building
 pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,8 @@ tabulate
 pytest
 pytest-asyncio
 pylint
+mypy==1.15.0
+mypy-extensions==1.0.0
 
 ## for building
 pyinstaller

--- a/src/config/attribute.py
+++ b/src/config/attribute.py
@@ -148,7 +148,7 @@ class BoolAttribute(Attribute):
         field_name: str,
         config: "ServiceConfig",
         required: bool = False,
-        default_value: Optional[str] = None,
+        default_value: Optional[bool] = None,
     ):
         super().__init__(field_name, config, required, default_value)
 

--- a/src/config/attribute.py
+++ b/src/config/attribute.py
@@ -9,7 +9,7 @@ class Attribute:
         field_name: str,
         config: ServiceConfig,
         required: bool = False,
-        default_value: Any = None,
+        default_value: Optional[Any] = None,
     ):
         self.field_name = field_name
         self.config = config
@@ -41,9 +41,9 @@ class IntAttribute(Attribute):
         field_name: str,
         config: ServiceConfig,
         required: bool = False,
-        min_value: int = None,
-        max_value: int = None,
-        default_value: int = None,
+        min_value: Optional[int] = None,
+        max_value: Optional[int] = None,
+        default_value: Optional[int] = None,
     ):
         self.min_value = min_value
         self.max_value = max_value
@@ -78,9 +78,9 @@ class FloatAttribute(Attribute):
         field_name: str,
         config: ServiceConfig,
         required: bool = False,
-        min_value: float = None,
-        max_value: float = None,
-        default_value: float = None,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+        default_value: Optional[float] = None,
     ):
         self.min_value = min_value
         self.max_value = max_value
@@ -113,7 +113,7 @@ class StringAttribute(Attribute):
         config: "ServiceConfig",
         required: bool = False,
         allowlist: Optional[list] = None,
-        default_value: str = None,
+        default_value: Optional[str] = None,
     ):
         self.allowlist = allowlist
         super().__init__(field_name, config, required, default_value)
@@ -148,7 +148,7 @@ class BoolAttribute(Attribute):
         field_name: str,
         config: "ServiceConfig",
         required: bool = False,
-        default_value: str = None,
+        default_value: Optional[str] = None,
     ):
         super().__init__(field_name, config, required, default_value)
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -34,8 +34,8 @@ class TrackerConfig:
             field_name="max_age_track",
             config=config,
             min_value=0,
-            max_value=1e5,
-            default_value=1e3,
+            max_value=100000,
+            default_value=1000,
         )
         self.min_distance_threshold = FloatAttribute(
             field_name="min_distance_threshold",

--- a/src/image/image.py
+++ b/src/image/image.py
@@ -1,4 +1,5 @@
 import io
+from typing import Optional
 
 import numpy as np
 import torch
@@ -18,7 +19,12 @@ def get_tensor_from_np_array(np_array: np.ndarray) -> torch.Tensor:
 
 
 class ImageObject:
-    def __init__(self, viam_image: ViamImage, pil_image: Image = None, device=None):
+    def __init__(
+        self,
+        viam_image: ViamImage,
+        pil_image: Optional[Image.Image] = None,
+        device=None
+    ):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         if pil_image is not None:
             self.pil_image = pil_image

--- a/src/tracker/track.py
+++ b/src/tracker/track.py
@@ -144,7 +144,7 @@ class Track:
     def get_detection(self, min_persistence=None) -> Detection:
         if self.is_candidate:
             if min_persistence is None:
-                return ValueError(
+                raise ValueError(
                     "Need to pass persistence in argument to get track candidate"
                 )
             class_name = self._get_label(min_persistence)

--- a/src/tracker/track.py
+++ b/src/tracker/track.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 import torch
 from viam.services.vision import Detection
@@ -31,11 +33,11 @@ class Track:
 
         self.label = label
 
-        self.label_from_reid = None
+        self.label_from_reid: Optional[str] = None
         self.conf_from_reid = 0
 
-        self.label_from_faceid = None
-        self.conf_from_faceid = None
+        self.label_from_faceid: Optional[str] = None
+        self.conf_from_faceid: Optional[str]  = None
 
         self.persistence: int = 0
         self.is_candidate: bool = is_candidate


### PR DESCRIPTION
I started looking at this due to the obvious errors in the type annotations mentioned in https://github.com/viam-modules/re-id-object-tracking/pull/23. 

When I started this branch, running `mypy main.py` gave 150ish errors. Between this PR and https://github.com/viamrobotics/viam-python-sdk/pull/846, it's down to 100ish errors. So, there's more to do, but this is at least a start. When there are no errors, we should add another CI check that running mypy (or any other type checker, if you want something else) has no errors.