### PR TITLE
[RSDK-10212] Adding eval script and higher resolution person detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Recomputes embeddings.
 
 | Name                              | Type   | Inclusion    | Default                                 | Description                                                                                                     |
 | --------------------------------- | ------ | ------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `detector_model_name`             | string | Optional| `'fasterrcnn_mobilenet_v3_large_320_fpn'` | Name of the model used for detection. Only option at the moment. |
+| `detector_model_name`             | string | Optional| `'fasterrcnn_mobilenet_v3_large_320_fpn'` | Name of the model used for detection. Only option at the moment. Options include `'fasterrcnn_mobilenet_v3_large_320_fpn'` (low resolution)  and `'fasterrcnn_mobilenet_v3_large_fpn'` (high resolution)  |
 | `detection_threshold`             | float  | Optional     | `0.8`                                   | Confidence threshold for detecting objects, with values ranging from 0.0 to 1.0.                                |
 | `detector_device`                 | string | Optional     | `'cpu'`                                 | Device on which the detection model will run. Options are `cpu` and `gpu`.                                      |
 
@@ -201,32 +201,3 @@ path
         └── Italian_Team
             └── another_group_picture.png
 ```
-<!--
-## PyInstaller Build Process
-
-This project includes a `Makefile` and a `build_installer.sh` script to automate the PyInstaller build process. PyInstaller is used to create standalone executables from the Python module scripts.
-
-### available `make` targets
-
-#### 1. `pyinstaller`
-This command builds the module executable using PyInstaller.
-
-##### Usage:
-
-```bash
-make pyinstaller
-```
-
-This creates the PyInstaller executable under `./pyinstaller_dist`
-
-#### 2. `clean-pyinstaller`
-
-This command removes the directories used by PyInstaller to store the build artifacts and distribution files.
-
-##### Usage:
-
-To build the project with the default paths:
-
-```bash
-make clean-pyinstaller
-``` -->

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Recomputes embeddings.
 
 | Name                              | Type   | Inclusion    | Default                                 | Description                                                                                                     |
 | --------------------------------- | ------ | ------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `detector_model_name`             | string | Optional| `'fasterrcnn_mobilenet_v3_large_320_fpn'` | Name of the model used for detection. Only option at the moment. Options include `'fasterrcnn_mobilenet_v3_large_320_fpn'` (low resolution)  and `'fasterrcnn_mobilenet_v3_large_fpn'` (high resolution)  |
-| `detection_threshold`             | float  | Optional     | `0.8`                                   | Confidence threshold for detecting objects, with values ranging from 0.0 to 1.0.                                |
+| `detector_model_name`             | string | Optional| `'fasterrcnn_mobilenet_v3_large_fpn'` | Name of the model used for detection. Only option at the moment. Options include `'fasterrcnn_mobilenet_v3_large_320_fpn'` (low resolution)  and `'fasterrcnn_mobilenet_v3_large_fpn'` (high resolution)  |
+| `detection_threshold`             | float  | Optional     | `0.9`                                   | Confidence threshold for detecting objects, with values ranging from 0.0 to 1.0.                                |
 | `detector_device`                 | string | Optional     | `'cpu'`                                 | Device on which the detection model will run. Options are `cpu` and `gpu`.                                      |
 
 

--- a/eval/eval_person_detection.py
+++ b/eval/eval_person_detection.py
@@ -1,0 +1,75 @@
+import argparse
+import asyncio
+
+import torch
+
+from src.config.config import ReIDObjetcTrackerConfig
+from src.image.image import ImageObject
+from src.tracker.detector.detector import get_detector
+from tests.fake_camera import FakeCamera
+from tests.utils import get_config
+
+CAMERA_NAME = "fake-camera"
+WORKING_CONFIG_DICT = {
+    "camera_name": CAMERA_NAME,
+    "path_to_database": "./something.db",
+    "_start_background_loop": False,
+    "detection_threshold": 0.1,
+    "detector_model_name": "fasterrcnn_mobilenet_v3_large_fpn",
+}
+
+
+async def main(img_path, threshold, detector_model_name):
+    cam = FakeCamera(CAMERA_NAME, img_path=img_path, use_ring_buffer=True)
+    device = torch.device("cpu")
+
+    # Getting detector configuration
+    config_dict = WORKING_CONFIG_DICT.copy()
+    config_dict["detection_threshold"] = threshold
+    config_dict["detector_model_name"] = detector_model_name
+    cfg = get_config(config_dict)
+    person_detector_config = ReIDObjetcTrackerConfig(cfg).detector_config
+    detector = get_detector(person_detector_config)
+
+    number_of_detections = 0
+    for i in range(cam.get_number_of_images()):
+        img = await cam.get_image(mime_type="image/jpeg")
+        img_object = ImageObject(img, device)
+        detections = detector.detect(img_object)
+        if len(detections) > 0:
+            print(f"Frame {i}: found {detections}")
+            number_of_detections += 1
+
+    print(
+        f"Found {number_of_detections} detection(s) with threshold {threshold} using model {detector_model_name}"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate person detection")
+    parser.add_argument(
+        "--img_path",
+        type=str,
+        help="Path to the image or directory of images",
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=0.8, help="Detection threshold"
+    )
+    parser.add_argument(
+        "--detector_model_name",
+        type=str,
+        default="fasterrcnn_mobilenet_v3_large_fpn",
+        choices=[
+            "fasterrcnn_mobilenet_v3_large_fpn",
+            "fasterrcnn_mobilenet_v3_large_320_fpn",
+        ],
+        help="Name of the person detector model to use",
+    )
+    args = parser.parse_args()
+
+    # Update the WORKING_CONFIG_DICT with the new model name
+    config_dict = WORKING_CONFIG_DICT.copy()
+    config_dict["detector_model_name"] = args.detector_model_name
+    config_dict["detection_threshold"] = args.threshold
+
+    asyncio.run(main(args.img_path, args.threshold, args.detector_model_name))

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -94,7 +94,7 @@ class DetectorConfig:
         self.model_name = StringAttribute(
             field_name="detector_model_name",
             config=config,
-            default_value="fasterrcnn_mobilenet_v3_large_320_fpn",
+            default_value="fasterrcnn_mobilenet_v3_large_fpn",
             allowlist=[
                 "fasterrcnn_mobilenet_v3_large_320_fpn",  # low resolution model (best effort to resize smallest edge to 320)
                 "fasterrcnn_mobilenet_v3_large_fpn",  #  higher resolution model (best effort to resize smallest edge to 800)
@@ -105,7 +105,7 @@ class DetectorConfig:
             config=config,
             min_value=0.0,
             max_value=1.0,
-            default_value=0.8,
+            default_value=0.9,
         )
         self.device = StringAttribute(
             field_name="detector_device",

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -95,7 +95,10 @@ class DetectorConfig:
             field_name="detector_model_name",
             config=config,
             default_value="fasterrcnn_mobilenet_v3_large_320_fpn",
-            allowlist=["fasterrcnn_mobilenet_v3_large_320_fpn"],
+            allowlist=[
+                "fasterrcnn_mobilenet_v3_large_320_fpn",  # low resolution model (best effort to resize smallest edge to 320)
+                "fasterrcnn_mobilenet_v3_large_fpn",  #  higher resolution model (best effort to resize smallest edge to 800)
+            ],
         )
         self.threshold = FloatAttribute(
             field_name="detection_threshold",

--- a/src/test_integration.py
+++ b/src/test_integration.py
@@ -7,6 +7,7 @@ from viam.services.vision import Vision
 
 from src.re_id_tracker import ReIDObjetcTracker
 from tests.fake_camera import FakeCamera
+from tests.utils import get_config
 
 CAMERA_NAME = "fake-camera"
 
@@ -28,14 +29,6 @@ WORKING_CONFIG_DICT = {
 
 
 IMG_PATH = "./tests/alex"
-
-
-def get_config(config_dict: Dict) -> ServiceConfig:
-    """returns a config from a dict"""
-    struct = Struct()
-    struct.update(dictionary=config_dict)
-    config = ServiceConfig(attributes=struct)
-    return config
 
 
 def get_vision_service(config_dict: Dict, reconfigure=True):

--- a/src/tracker/detector/detector.py
+++ b/src/tracker/detector/detector.py
@@ -28,7 +28,10 @@ def get_detector(cfg: DetectorConfig) -> Detector:
     Factory function to return the correct detector based on the configuration.
     """
     # Delay the import of TorchvisionDetector to avoid circular imports
-    if cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_320_fpn":
+    if (
+        cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_320_fpn"
+        or cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_fpn"
+    ):
         from src.tracker.detector.torchvision_detector import TorchvisionDetector
 
         return TorchvisionDetector(cfg)

--- a/tests/fake_camera.py
+++ b/tests/fake_camera.py
@@ -17,8 +17,6 @@ def load_ordered_images(folder_path: str) -> List[Image.Image]:
 
     # Filter out non-jpg files if necessary and sort the list
     image_files = sorted([f for f in image_files if f.endswith(".jpg")])
-
-    # Load images in order
     images = [Image.open(os.path.join(folder_path, img)) for img in image_files]
 
     return images
@@ -90,3 +88,11 @@ class FakeCamera(Camera):
         :return: A tuple containing the point cloud data.
         """
         raise NotImplementedError
+
+    def get_number_of_images(self) -> int:
+        """
+        Get the number of images in the list or ring buffer.
+
+        :return: The number of images.
+        """
+        return len(self.images)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from google.protobuf.struct_pb2 import Struct
+from viam.proto.app.robot import ServiceConfig
+
+
+def get_config(config_dict: Dict) -> ServiceConfig:
+    """returns a config populated with picture_directory and camera_name
+    attributes.
+
+    Returns:
+        ServiceConfig: _description_
+    """
+    struct = Struct()
+    struct.update(dictionary=config_dict)
+    config = ServiceConfig(attributes=struct)
+    return config


### PR DESCRIPTION
## Eval script

To run evaluation please run:
```
cd re-id-object-tracking
export PYTHONPATH=$(pwd)
python eval/eval_person_detection.py --threshold=0.9 --img_path=path/to/image/files detector_model_name=[fasterrcnn_mobilenet_v3_large_fpn or fasterrcnn_mobilenet_v3_large_320_fpn]
```
### Arguments description:
`python eval/eval_person_detection.py -h`

### Convert `mp4` video to images:
You can use[ this gist](https://gist.github.com/Rob1in/f922f3aa28f032306fb99ff7da50f212) <--- follow up PR is just passing a video path


## Higher resolution person detection

Torchvision offers 2  FasterRCNN detection models with MobileNet as a backbone: one large resolution and one low resolution. Both are now configurable with the module argument `detector_model_name`.

Depending on that choice, **the model** makes a best effort to resize the smallest edge to either [320](https://github.com/pytorch/vision/blob/8ea4772e97bc11b2cfee48a415e7df8cd17fa682/torchvision/models/detection/faster_rcnn.py#L761) (low resolution) or [800](https://github.com/pytorch/vision/blob/8ea4772e97bc11b2cfee48a415e7df8cd17fa682/torchvision/models/detection/faster_rcnn.py#L172) (higher resolution) while keeping the origin aspect ration. See source code of [`GeneralizedRCNNTransform`](https://github.com/pytorch/vision/blob/8ea4772e97bc11b2cfee48a415e7df8cd17fa682/torchvision/models/detection/transform.py#L179).

Still working on reproducing the false positive but this is a first step