### PR TITLE
A resilient tracker

### DIFF
--- a/src/re_id_tracker.py
+++ b/src/re_id_tracker.py
@@ -226,9 +226,6 @@ class ReIDObjetcTracker(Vision, Reconfigurable):
             await component.close()
 
         """
-        try:
-            await self.tracker.stop()
-            await super().close()
-        except Exception as e:
-            LOGGER.error(f"Error closing tracker: {e}")
+        await self.tracker.stop()
+        await super().close()
         return

--- a/src/re_id_tracker.py
+++ b/src/re_id_tracker.py
@@ -226,7 +226,9 @@ class ReIDObjetcTracker(Vision, Reconfigurable):
             await component.close()
 
         """
-        await self.tracker.stop()  # TODO: ask Naveed
-        await super().close()
-
+        try:
+            await self.tracker.stop()
+            await super().close()
+        except Exception as e:
+            LOGGER.error(f"Error closing tracker: {e}")
         return

--- a/src/tracker/tracker.py
+++ b/src/tracker/tracker.py
@@ -152,7 +152,8 @@ class Tracker:
     async def get_and_decode_img(self):
         try:
             viam_img = await self.camera.get_image(mime_type=CameraMimeType.JPEG)
-        except:
+        except Exception as e:
+            LOGGER.error(f"Error getting image: {e}")
             return None
         return ImageObject(viam_img, self.device)
 

--- a/src/tracker/tracker.py
+++ b/src/tracker/tracker.py
@@ -120,8 +120,11 @@ class Tracker:
         self.stop_event.set()
         self.new_object_notifier.close()
         self.tracks_manager.close()
-        if self.background_task is not None:
-            await self.background_task  # Wait for the background task to finish
+        try:
+            if self.background_task is not None:
+                await self.background_task  # Wait for the background task to finish
+        except Exception as e:
+            LOGGER.error(f"Error stopping background task: {e}")
 
     def import_tracks_from_tracks_manager(self):
         self.tracks = self.tracks_manager.get_tracks_on_disk()

--- a/src/tracker/tracker.py
+++ b/src/tracker/tracker.py
@@ -149,7 +149,13 @@ class Tracker:
                     if torch.equal(img.uint8_tensor, self.last_image.uint8_tensor):
                         continue
                     self.last_image = img
-                self.update(img)  # Update tracks
+                try:
+                    self.update(img)  # Update tracks
+                except Exception as e:
+                    LOGGER.error(f"Error updating tracker: {e}")
+                    await sleep(
+                        self.sleep_period * 5
+                    )  # sleep a bit more if something bad happened
             await sleep(self.sleep_period)
 
     async def get_and_decode_img(self):


### PR DESCRIPTION
The symptoms of the problem were phantom detections that persisted forever.
We would get an error log of this error but it surfaced much after the stuck state started.
The error that we noticed was due to wrong bounding boxes coordinates - ones that don't satisfy this requirement:
" [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H."
This requirement is supposedly guaranteed by torchvision model (see [here](https://github.com/pytorch/vision/blob/ef4718ad85dab0a3694b0c3f740f46ab891f50cc/torchvision/models/detection/faster_rcnn.py#L65)) but anyway, now it's caught.


This error happens in the background loop, which is in charge of pulling an image from the camera and processing it (person detection, person re-identification, face detection, face re-identification). To see the impact of a raised error in the background loop, I purposely raised an error (in the background loop) after some frames. I observed a few things:

- it does put the tracker in the stuck state where it keeps returning the same detection (crashed background loop doesn't update `current_detections`)

- the module is not able to reconfigure ( = creating a new `Tracker` instance),  even though the robot itself reconfigures and the detections persist. This is because when a background task (`self.tracker.background_task`) raises an exception, that exception is stored in the task object. When you try to await that task again (which happens in `tracker.stop()`), the exception is re-raised. So I added a try/except here, which enables to execute the stop() function of the tracker even if the background loop crashed. 

- Also added try/except blocks to catch `get_image()` errors and `tracker.update()` errors.
