### PR TITLE
RSDK-10474 : Add crop region

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ database file does not exist yet, it will be created.
 ```json
 {
   "camera_name": "camera-1",
-  "path_to_database": "/path/to/database.db"
+  "path_to_database": "/path/to/database.db",
+  #optional
+  "crop_region": {
+    "x2_rel": 1,
+    "y2_rel": 1,
+    "x1_rel": 0.5,
+    "y1_rel": 0.5
+  }
 }
 ```
 
@@ -114,6 +121,8 @@ Recomputes embeddings.
 | `save_period`      | int    | Optional     | `20`    | Interval (in number of tracking steps) when tracks are saved to the database.               |
 | `start_fresh`             | bool   | Optional  | `False`       | Whether or not to load the tracks from the database at `reconfigure()`.                             |
 | `path_to_known_persons`   | string | Optional  | `None`        | Path to the database containing pictures of entire persons. If the directory does not exist it will be created at `reconfigure()`. Refer [example directory tree](#example-of-directory-tree) to see how to add pictures of known persons and associate labels with the persons.            |
+| `crop_region`             | dict   | Optional  | `None`        | Defines a region of the image to crop for processing. Must include four float values between 0 and 1: `x1_rel`, `y1_rel`, `x2_rel`, `y2_rel` representing the relative coordinates of the crop region. |
+
 
 
 ### Person detector attributes

--- a/src/config/attribute.py
+++ b/src/config/attribute.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from viam.proto.app.robot import ServiceConfig
 
@@ -7,39 +7,28 @@ class Attribute:
     def __init__(
         self,
         field_name: str,
-        config: ServiceConfig,
         required: bool = False,
         default_value: Optional[Any] = None,
     ):
         self.field_name = field_name
-        self.config = config
         self.required = required
         self.default_value = default_value
-        self.value = None
-        self.set_value()
 
-    def validate(self, value: Any):
+    def validate(self, config: "ServiceConfig", value=None):
+        if value is not None:
+            return value
+        value = config.attributes.fields.get(self.field_name, self.default_value)
         if self.required and value is None:
             raise ValueError(
                 f"Missing required configuration attribute: {self.field_name}"
             )
         return value
 
-    def set_value(self):
-        value = self.config.attributes.fields.get(self.field_name, self.default_value)
-        if self.required and value is None:
-            raise ValueError(
-                f"Missing required configuration attribute: {self.field_name}"
-            )
-        self.value = self.validate(value)
-        return self.value
-
 
 class IntAttribute(Attribute):
     def __init__(
         self,
         field_name: str,
-        config: ServiceConfig,
         required: bool = False,
         min_value: Optional[int] = None,
         max_value: Optional[int] = None,
@@ -47,10 +36,10 @@ class IntAttribute(Attribute):
     ):
         self.min_value = min_value
         self.max_value = max_value
-        super().__init__(field_name, config, required, default_value)
+        super().__init__(field_name, required, default_value)
 
-    def validate(self, value: Any):
-        value = super().validate(value)
+    def validate(self, config: "ServiceConfig", value=None):
+        value = super().validate(config, value)
         if not isinstance(value, (float, int)):
             if not hasattr(value, "number_value"):
                 raise ValueError(
@@ -76,7 +65,6 @@ class FloatAttribute(Attribute):
     def __init__(
         self,
         field_name: str,
-        config: ServiceConfig,
         required: bool = False,
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
@@ -84,10 +72,10 @@ class FloatAttribute(Attribute):
     ):
         self.min_value = min_value
         self.max_value = max_value
-        super().__init__(field_name, config, required, default_value)
+        super().__init__(field_name, required, default_value)
 
-    def validate(self, value: Any):
-        value = super().validate(value)
+    def validate(self, config: "ServiceConfig", value=None):
+        value = super().validate(config, value)
         if not isinstance(value, (float, int)):
             if not hasattr(value, "number_value"):
                 raise ValueError(
@@ -110,16 +98,15 @@ class StringAttribute(Attribute):
     def __init__(
         self,
         field_name: str,
-        config: "ServiceConfig",
         required: bool = False,
         allowlist: Optional[list] = None,
         default_value: Optional[str] = None,
     ):
         self.allowlist = allowlist
-        super().__init__(field_name, config, required, default_value)
+        super().__init__(field_name, required, default_value)
 
-    def validate(self, value: Any):
-        value = super().validate(value)
+    def validate(self, config: "ServiceConfig", value=None):
+        value = super().validate(config, value)
         if value is None:
             return value
         if not isinstance(value, str):  # if it's not the default value
@@ -146,14 +133,13 @@ class BoolAttribute(Attribute):
     def __init__(
         self,
         field_name: str,
-        config: "ServiceConfig",
         required: bool = False,
         default_value: Optional[bool] = None,
     ):
-        super().__init__(field_name, config, required, default_value)
+        super().__init__(field_name, required, default_value)
 
-    def validate(self, value: Any):
-        value = super().validate(value)
+    def validate(self, config: "ServiceConfig", value=None):
+        value = super().validate(config, value)
         if not isinstance(value, bool):  # if it's not the default value
             if not hasattr(
                 value, "bool_value"
@@ -172,47 +158,21 @@ class DictAttribute(Attribute):
     def __init__(
         self,
         field_name: str,
-        config: "ServiceConfig",
         required: bool = False,
-        required_fields: Optional[list[str]] = None,
+        fields: Optional[List["Attribute"]] = None,
         default_value: Optional[dict] = None,
     ):
-        self.required_fields = required_fields or []
-        super().__init__(field_name, config, required, default_value or {})
+        self.fields = fields or []
+        super().__init__(field_name, required, default_value)
 
-    def validate(self, value: Any):
-        value = super().validate(value)
+    def validate(self, config: "ServiceConfig", value=None):
+        value = super().validate(config)
         if value is None:
-            return {}
-
-        if not isinstance(value, dict):
-            if not hasattr(value, "struct_value"):
-                raise ValueError(
-                    f"Expected dictionary for '{self.field_name}', got {type(value).__name__}"
-                )
-            # Convert from protobuf struct to Python dict
-            value = {k: v.string_value for k, v in value.struct_value.fields.items()}
-
-        # Check for required fields
-        missing_fields = [field for field in self.required_fields if field not in value]
-        if missing_fields:
-            raise ValueError(
-                f"Missing required fields in '{self.field_name}': {missing_fields}"
+            return value
+        value = dict(value.struct_value.fields)
+        for attribute in self.fields:
+            value[attribute.field_name] = attribute.validate(
+                config, value[attribute.field_name]
             )
 
         return value
-
-    def __getitem__(self, key):
-        return self.value[key]
-
-    def get(self, key, default=None):
-        return self.value.get(key, default)
-
-    def items(self):
-        return self.value.items()
-
-    def keys(self):
-        return self.value.keys()
-
-    def values(self):
-        return self.value.values()

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -13,218 +13,196 @@ class TrackerConfig:
     def __init__(self, config: "ServiceConfig"):
         self.re_id_threshold = FloatAttribute(
             field_name="re_id_threshold",
-            config=config,
             min_value=0,
             default_value=0.3,
-        )
+        ).validate(config)
 
         self.min_track_persistence = IntAttribute(
             field_name="min_track_persistence",
-            config=config,
             min_value=0,
             default_value=4,
-        )
+        ).validate(config)
         self.lambda_value = FloatAttribute(
             field_name="lambda_value",
-            config=config,
             min_value=0,
             max_value=1,
             default_value=0.95,
-        )
+        ).validate(config)
         self.max_age_track = IntAttribute(
             field_name="max_age_track",
-            config=config,
             min_value=0,
             max_value=100000,
             default_value=1000,
-        )
+        ).validate(config)
         self.min_distance_threshold = FloatAttribute(
             field_name="min_distance_threshold",
-            config=config,
             min_value=0,
             max_value=1,
             default_value=0.3,
-        )
+        ).validate(config)
         self.feature_distance_metric = StringAttribute(
             field_name="feature_distance_metric",
-            config=config,
             default_value="cosine",
             allowlist=["cosine", "euclidean"],
-        )
+        ).validate(config)
 
         self.max_frequency = FloatAttribute(
             field_name="max_frequency_hz",
-            config=config,
             default_value=10,
             min_value=0.1,
             max_value=100,
-        )
+        ).validate(config)
 
         self.cooldown_period = FloatAttribute(
             field_name="cooldown_period_s",
-            config=config,
             default_value=5,
             min_value=0,
-        )
+        ).validate(config)
 
         self.start_fresh = BoolAttribute(
             field_name="start_fresh",
-            config=config,
             default_value=False,
-        )
+        ).validate(config)
 
         self.save_to_db = BoolAttribute(
             field_name="save_to_db",
-            config=config,
             default_value=True,
-        )
+        ).validate(config)
 
         self._start_background_loop = BoolAttribute(
-            field_name="_start_background_loop", config=config, default_value=True
-        )
+            field_name="_start_background_loop", default_value=True
+        ).validate(config)
 
         self.path_to_known_persons = StringAttribute(
             field_name="path_to_known_persons",
-            config=config,
             default_value=None,
-        )
+        ).validate(config)
 
         self.crop_region = DictAttribute(
             field_name="crop_region",
-            config=config,
             default_value=None,
-            required_fields=["x1_rel", "y1_rel", "x2_rel", "y2_rel"],
-        )
+            fields=[
+                FloatAttribute(field_name="x1_rel", min_value=0, max_value=1),
+                FloatAttribute(field_name="y1_rel", min_value=0, max_value=1),
+                FloatAttribute(field_name="x2_rel", min_value=0, max_value=1),
+                FloatAttribute(field_name="y2_rel", min_value=0, max_value=1),
+            ],
+        ).validate(config)
 
 
 class DetectorConfig:
     def __init__(self, config: "ServiceConfig"):
         self.model_name = StringAttribute(
             field_name="detector_model_name",
-            config=config,
             default_value="fasterrcnn_mobilenet_v3_large_320_fpn",
             allowlist=[
                 "fasterrcnn_mobilenet_v3_large_320_fpn",  # low resolution model (best effort to resize smallest edge to 320)
                 "fasterrcnn_mobilenet_v3_large_fpn",  #  higher resolution model (best effort to resize smallest edge to 800)
             ],
-        )
+        ).validate(config)
         self.threshold = FloatAttribute(
             field_name="detection_threshold",
-            config=config,
             min_value=0.0,
             max_value=1.0,
             default_value=0.95,
-        )
+        ).validate(config)
         self.device = StringAttribute(
             field_name="detector_device",
-            config=config,
             default_value="cpu",
             allowlist=["cpu", "cuda"],
-        )
+        ).validate(config)
 
         # TODO: add usage for torchvision
         self.max_results = IntAttribute(
             field_name="detection_max_detection_results",
-            config=config,
             default_value=5,
             min_value=1,
-        )
+        ).validate(config)
 
         self._enable_debug_tools = BoolAttribute(
-            field_name="_enable_debug_tools", config=config, default_value=False
-        )
+            field_name="_enable_debug_tools", default_value=False
+        ).validate(config)
 
         self._path_to_debug_directory = StringAttribute(
             field_name="_path_to_debug_directory",
-            config=config,
             default_value=None,
-        )
+        ).validate(config)
 
         self._max_size_debug_directory = IntAttribute(
-            field_name="_max_size_debug_directory", config=config, default_value=200
-        )
+            field_name="_max_size_debug_directory", default_value=200
+        ).validate(config)
 
 
 class FaceIdConfig:
     def __init__(self, config: ServiceConfig):
         self.path_to_known_faces = StringAttribute(
             field_name="path_to_known_faces",
-            config=config,
             default_value=None,
-        )
+        ).validate(config)
 
         self.device = StringAttribute(
             field_name="face_detector_device",
-            config=config,
             default_value="cpu",
             allowlist=["cpu", "cuda"],
-        )
+        ).validate(config)
 
         self.detector = StringAttribute(
             field_name="face_detector_model",
-            config=config,
             default_value="ultraface_version-RFB-320-int8",
-        )
+        ).validate(config)
 
         self.detector_threshold = FloatAttribute(
             field_name="face_detection_threshold",
-            config=config,
             min_value=0.0,
             max_value=1.0,
             default_value=0.9,
-        )
+        ).validate(config)
 
         self.feature_extractor = StringAttribute(
             field_name="face_feature_extractor_model",
-            config=config,
             default_value="facenet",
-        )
+        ).validate(config)
 
         self.cosine_id_threshold = FloatAttribute(
             field_name="cosine_id_threshold",
-            config=config,
             min_value=0.0,
             max_value=1.0,
             default_value=0.3,
-        )
+        ).validate(config)
 
         self.euclidean_id_threshold = FloatAttribute(
             field_name="euclidean_id_threshold",
-            config=config,
             min_value=0.0,
             max_value=1.0,
             default_value=0.9,
-        )
+        ).validate(config)
 
 
 class FeatureEncoderConfig:
     def __init__(self, config: ServiceConfig):
         self.feature_extractor_name = StringAttribute(
             field_name="feature_extractor_model",
-            config=config,
             default_value="osnet_ain_x1_0",
             allowlist=["osnet_x0_25", "osnet_ain_x1_0"],
-        )
+        ).validate(config)
 
         self.device = StringAttribute(
             field_name="feature_encoder_device",
-            config=config,
             default_value="cuda",
             allowlist=["cpu", "cuda"],
-        )
+        ).validate(config)
 
 
 class TracksManagerConfig:
     def __init__(self, config: "ServiceConfig"):
         self.path_to_db = StringAttribute(
-            field_name="path_to_database", config=config, required=True
-        )
+            field_name="path_to_database", required=True
+        ).validate(config)
 
         self.save_period = IntAttribute(
             field_name="save_period",
-            config=config,
             default_value=20,
-        )
+        ).validate(config)
 
 
 class ReIDObjetcTrackerConfig:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -2,6 +2,7 @@ from viam.proto.app.robot import ServiceConfig
 
 from src.config.attribute import (
     BoolAttribute,
+    DictAttribute,
     FloatAttribute,
     IntAttribute,
     StringAttribute,
@@ -86,6 +87,13 @@ class TrackerConfig:
             field_name="path_to_known_persons",
             config=config,
             default_value=None,
+        )
+
+        self.crop_region = DictAttribute(
+            field_name="crop_region",
+            config=config,
+            default_value=None,
+            required_fields=["x1_rel", "y1_rel", "x2_rel", "y2_rel"],
         )
 
 

--- a/src/image/image.py
+++ b/src/image/image.py
@@ -39,27 +39,27 @@ class ImageObject:
             )  # -> in (H, W, C)
 
         self.np_array = np.array(self.pil_image, dtype=np.uint8)
-        uint8_tensor, float32_tensor = get_tensor_from_np_array(
-            self.np_array, crop_region
-        )
+        uint8_tensor, float32_tensor = get_tensor_from_np_array(self.np_array)
         self.uint8_tensor = uint8_tensor.to(self.device)
         self.float32_tensor = float32_tensor.to(self.device)
 
         if crop_region is not None:
             # Get image dimensions
-            _, height, width = uint8_tensor.shape
+            self.width = uint8_tensor.shape[2]
+            self.height = uint8_tensor.shape[1]
 
             # Convert relative coordinates (0.0-1.0) to absolute pixel positions
-            x1 = int(crop_region.get("x1", 0.0) * width)
-            y1 = int(crop_region.get("y1", 0.0) * height)
-            x2 = int(crop_region.get("x2", 1.0) * width)
-            y2 = int(crop_region.get("y2", 1.0) * height)
+
+            x1 = int(crop_region.get("x1_rel", 0.0) * self.width)
+            y1 = int(crop_region.get("y1_rel", 0.0) * self.height)
+            x2 = int(crop_region.get("x2_rel", 1.0) * self.width)
+            y2 = int(crop_region.get("y2_rel", 1.0) * self.height)
 
             # Ensure coordinates are within image bounds
-            x1 = max(0, min(x1, width - 1))
-            y1 = max(0, min(y1, height - 1))
-            x2 = max(x1 + 1, min(x2, width))
-            y2 = max(y1 + 1, min(y2, height))
+            x1 = max(0, min(x1, self.width - 1))
+            y1 = max(0, min(y1, self.height - 1))
+            x2 = max(x1 + 1, min(x2, self.width))
+            y2 = max(y1 + 1, min(y2, self.height))
 
             # Apply cropping to both tensors
             self.uint8_tensor = uint8_tensor[:, y1:y2, x1:x2]

--- a/src/tracker/detector/detector.py
+++ b/src/tracker/detector/detector.py
@@ -29,11 +29,11 @@ def get_detector(cfg: DetectorConfig) -> Detector:
     """
     # Delay the import of TorchvisionDetector to avoid circular imports
     if (
-        cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_320_fpn"
-        or cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_fpn"
+        cfg.model_name == "fasterrcnn_mobilenet_v3_large_320_fpn"
+        or cfg.model_name == "fasterrcnn_mobilenet_v3_large_fpn"
     ):
         from src.tracker.detector.torchvision_detector import TorchvisionDetector
 
         return TorchvisionDetector(cfg)
     else:
-        raise ValueError(f"Model {cfg.model_name.value} is not supported.")
+        raise ValueError(f"Model {cfg.model_name} is not supported.")

--- a/src/tracker/detector/mediapipe.py
+++ b/src/tracker/detector/mediapipe.py
@@ -46,7 +46,7 @@ class Detector:
         :param max_results: Maximum number of detection results to return.
         """
 
-        model_name = cfg.model_name.value
+        model_name = cfg.model_name
         self.model_config = DETECTORS_CONFIG.get(model_name)
 
         BaseOptions = mp.tasks.BaseOptions
@@ -57,9 +57,9 @@ class Detector:
             base_options=BaseOptions(
                 model_asset_path=self.model_config.get_model_path()
             ),
-            max_results=cfg.max_results.value,
+            max_results=cfg.max_results,
             running_mode=VisionRunningMode.IMAGE,
-            score_threshold=cfg.threshold.value,
+            score_threshold=cfg.threshold,
             category_allowlist=["person"],
         )
         self.detector = vision.ObjectDetector.create_from_options(self.options)

--- a/src/tracker/detector/torchvision_detector.py
+++ b/src/tracker/detector/torchvision_detector.py
@@ -26,18 +26,18 @@ ssl._create_default_https_context = ssl._create_unverified_context
 class TorchvisionDetector(Detector):
     def __init__(self, cfg: DetectorConfig):
         super().__init__(cfg)
-        if cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_320_fpn":
+        if cfg.model_name == "fasterrcnn_mobilenet_v3_large_320_fpn":
             weights = FasterRCNN_MobileNet_V3_Large_320_FPN_Weights.COCO_V1
             self.model = fasterrcnn_mobilenet_v3_large_320_fpn(
                 weights=weights,
-                box_score_thresh=cfg.threshold.value,
+                box_score_thresh=cfg.threshold,
                 num_classes=91,
             )
-        elif cfg.model_name.value == "fasterrcnn_mobilenet_v3_large_fpn":
+        elif cfg.model_name == "fasterrcnn_mobilenet_v3_large_fpn":
             weights = FasterRCNN_MobileNet_V3_Large_FPN_Weights.COCO_V1
             self.model = fasterrcnn_mobilenet_v3_large_fpn(
                 weights=weights,
-                box_score_thresh=cfg.threshold.value,
+                box_score_thresh=cfg.threshold,
                 num_classes=91,
             )
 
@@ -47,23 +47,23 @@ class TorchvisionDetector(Detector):
             )
 
         self.categories = weights.meta["categories"]
-        self.threshold = cfg.threshold.value  # TODO: do it in the detector super class
+        self.threshold = cfg.threshold  # TODO: do it in the detector super class
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model.to(self.device)
         self.model.eval()
         self.transform = weights.transforms()
 
         # Debug configuration
-        self._enable_debug_tools = cfg._enable_debug_tools.value
+        self._enable_debug_tools = cfg._enable_debug_tools
         if self._enable_debug_tools:
-            if cfg._path_to_debug_directory.value is None:
+            if cfg._path_to_debug_directory is None:
                 raise ValueError(
                     "path_to_debug_directory is not set but _enable_debug_tools is set to true. Please set it to a valid path."
                 )
-            self._path_to_debug_directory = cfg._path_to_debug_directory.value
+            self._path_to_debug_directory = cfg._path_to_debug_directory
             if not os.path.exists(self._path_to_debug_directory):
                 os.makedirs(self._path_to_debug_directory)
-            self._max_size_debug_directory = cfg._max_size_debug_directory.value
+            self._max_size_debug_directory = cfg._max_size_debug_directory
 
     def detect(self, image: ImageObject, visualize: bool = False) -> List[Detection]:
         preprocessed_image = self.transform(image.uint8_tensor)

--- a/src/tracker/encoder/feature_encoder.py
+++ b/src/tracker/encoder/feature_encoder.py
@@ -38,10 +38,10 @@ def get_encoder(cfg: FeatureEncoderConfig) -> FeatureEncoder:
     Factory function to return the correct detector based on the configuration.
     """
     # Delay the import of TorchvisionDetector to avoid circular imports
-    model_name: str = cfg.feature_extractor_name.value
+    model_name: str = cfg.feature_extractor_name
     if model_name.startswith("osnet_"):
         from src.tracker.encoder.os_net.os_net_encoder import OSNetFeatureEncoder
 
         return OSNetFeatureEncoder(cfg)
     else:
-        raise ValueError(f"Model {cfg.model_name.value} is not supported.")
+        raise ValueError(f"Model {cfg.model_name} is not supported.")

--- a/src/tracker/encoder/os_net/os_net_encoder.py
+++ b/src/tracker/encoder/os_net/os_net_encoder.py
@@ -79,7 +79,7 @@ class OSNetFeatureEncoder(FeatureEncoder):
         :param device: The device to run the model on ('cpu' or 'cuda').
         """
 
-        if cfg.device.value == "cuda":
+        if cfg.device == "cuda":
             if not torch.cuda.is_available():
                 LOGGER.warning(
                     "'feature_encoder_device' is set to 'cuda' but cuda is not avalaible. using cpu instead"
@@ -94,7 +94,7 @@ class OSNetFeatureEncoder(FeatureEncoder):
             use_gpu = False
             self.device = torch.device("cpu")
 
-        self.model_config = ENCODERS_CONFIG.get(cfg.feature_extractor_name.value)
+        self.model_config = ENCODERS_CONFIG.get(cfg.feature_extractor_name)
 
         model_name = "osnet_ain_x1_0"  # cfg.feature_extractor_name.value
         if model_name == "osnet_ain_x1_0":

--- a/src/tracker/face_id/face_detector.py
+++ b/src/tracker/face_id/face_detector.py
@@ -61,7 +61,7 @@ class FaceDetector:
         cfg: FaceIdConfig,
         debug: bool = False,
     ):
-        self.model_config = ENCODERS_CONFIG.get(cfg.detector.value)
+        self.model_config = ENCODERS_CONFIG.get(cfg.detector)
         model_path = self.model_config.get_model_path()
         self.input_size = self.model_config.input_size
         providers = ["CPUExecutionProvider"]
@@ -78,7 +78,7 @@ class FaceDetector:
             0
         ].name  # Assuming this is confidences
         self.box_output_name = self.session.get_outputs()[1].name
-        self.threshold = cfg.detector_threshold.value
+        self.threshold = cfg.detector_threshold
         self.debug = debug
         self.margin = 0
 

--- a/src/tracker/face_id/face_net/facenet_extractor.py
+++ b/src/tracker/face_id/face_net/facenet_extractor.py
@@ -51,7 +51,7 @@ ENCODERS_CONFIG: Dict[str, EncoderModelConfig] = {
 
 class FaceFeaturesExtractor:
     def __init__(self, cfg: FaceIdConfig):
-        self.model_config = ENCODERS_CONFIG.get(cfg.feature_extractor.value)
+        self.model_config = ENCODERS_CONFIG.get(cfg.feature_extractor)
         model_path = self.model_config.get_model_path()
         self.input_shape = self.model_config.input_shape
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/src/tracker/face_id/identifier.py
+++ b/src/tracker/face_id/identifier.py
@@ -99,8 +99,8 @@ class FaceIdentifier:
 
                 # Check if distances meet the thresholds
                 if (
-                    cos_dist < self.cfg.cosine_id_threshold.value
-                    and euc_dist <= self.cfg.euclidean_id_threshold.value
+                    cos_dist < self.cfg.cosine_id_threshold
+                    and euc_dist <= self.cfg.euclidean_id_threshold
                 ):
                     # Update the best match if the cosine distance is smaller
                     if cos_dist < min_cos_dist:
@@ -114,7 +114,7 @@ class FaceIdentifier:
         """
         Computes embeddings for known faces from the picture directory.
         """
-        path_to_known_faces = self.cfg.path_to_known_faces.value
+        path_to_known_faces = self.cfg.path_to_known_faces
         if path_to_known_faces is None:
             return
         if not os.path.exists(path_to_known_faces):

--- a/src/tracker/face_id/sface/sface_extractor.py
+++ b/src/tracker/face_id/sface/sface_extractor.py
@@ -59,7 +59,7 @@ class FaceFeaturesExtractor:
         debug: bool = False,
     ):
         self.debug = debug
-        self.model_config = ENCODERS_CONFIG.get(cfg.feature_extractor.value)
+        self.model_config = ENCODERS_CONFIG.get(cfg.feature_extractor)
         model_path = self.model_config.get_model_path()
         self.input_shape = self.model_config.input_shape
 
@@ -125,6 +125,6 @@ class FaceFeaturesExtractor:
         elif self.model_config.metric == "manhattan":
             distance = cityblock(feature_vector_1, feature_vector_2)
         else:
-            raise ValueError(f"Unsupported metric '{self.model_config.metric }'")
+            raise ValueError(f"Unsupported metric '{self.model_config.metric}'")
 
         return (distance - self.model_config.mean) / self.model_config.std

--- a/src/tracker/track.py
+++ b/src/tracker/track.py
@@ -171,10 +171,10 @@ class Track:
             y_offset = int(crop_region.get("y1_rel", 0.0) * original_image_height)
 
             # Convert back to original image coordinates
-            x_min = x_min + x_offset
-            y_min = y_min + y_offset
-            x_max = x_max + x_offset
-            y_max = y_max + y_offset
+            x_min = min(original_image_width - 1, x_min + x_offset)
+            y_min = min(original_image_height - 1, y_min + y_offset)
+            x_max = min(original_image_width - 1, x_max + x_offset)
+            y_max = min(original_image_height - 1, y_max + y_offset)
 
         return Detection(
             x_min=x_min,

--- a/src/tracker/tracker.py
+++ b/src/tracker/tracker.py
@@ -45,6 +45,7 @@ class Tracker:
         self.max_age_track = cfg.tracker_config.max_age_track.value
         self.distance = cfg.tracker_config.feature_distance_metric.value
         self.sleep_period = 1 / (cfg.tracker_config.max_frequency.value)
+        self.crop_region = cfg.tracker_config.crop_region.value
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -164,7 +165,7 @@ class Tracker:
         except Exception as e:
             LOGGER.error(f"Error getting image: {e}")
             return None
-        return ImageObject(viam_img, self.device)
+        return ImageObject(viam_img, self.device, self.crop_region)
 
     def relabel_tracks(self, dict_old_label_new_label: Dict[str, str]):
         answer = {}

--- a/src/tracker/tracks_manager.py
+++ b/src/tracker/tracks_manager.py
@@ -36,7 +36,7 @@ class TracksManager:
     def __init__(self, config: TracksManagerConfig):
         self.tracks_on_disk: Dict[str, Track] = {}
         self.category_count_on_disk: Dict[str, int] = {}
-        self.path_to_database = config.path_to_db.value
+        self.path_to_database = config.path_to_db
         self.track_ids_with_label_on_disk: Dict[str, List[str]] = {}
         self.save_period = config.save_period
         self.con: sqlite3.Connection = sqlite3.connect(self.path_to_database)


### PR DESCRIPTION
Add a new argument that should look like this:
`"crop_region": {
    "x1_rel": 0.5,
    "x2_rel": 1,
    "y1_rel": 1,
    "y2_rel": 0.0
  },`
  
  What happens is that we first crop the tensor (while keeping the viam_image the same since we want to return it) and the nretrieve bbox coordinates in the original image frame